### PR TITLE
Fixed Sort buttons and text box

### DIFF
--- a/src/main/resources/static/CSS/traits-style.css
+++ b/src/main/resources/static/CSS/traits-style.css
@@ -119,8 +119,9 @@ button:hover {
 }
 
 fieldset {
-    min-width: 48vh;
-    min-height: 7vh;
+    /* min-width: 48vh; */
+    min-width: 450px;
+    min-height: 70px;
 }
 
 legend {
@@ -137,6 +138,7 @@ legend {
 
 .search-boxes input {
     min-height: 20px;
+    min-width: 450px;
     margin-bottom: 5px;
 }
 


### PR DESCRIPTION
- Set the widths of the 'fieldset' div and the input text boxes so they don't deform on smaller screens.